### PR TITLE
Add line about AUR package.

### DIFF
--- a/source/download/index.html.slim
+++ b/source/download/index.html.slim
@@ -40,6 +40,12 @@
           wget http://s3.amazonaws.com/influxdb/influxdb-latest-1.i686.rpm
           sudo rpm -ivh influxdb-latest-1.i686.rpm
 
+    h2 Arch Linux
+    p
+      'An AUR package is available
+      a href="https://aur.archlinux.org/packages/influxdb/" here
+      '.
+
     h2 All Versions
     p Here's a list of all the available builds and versions that we've released.
     ul#file_list


### PR DESCRIPTION
Hey!

I spent some time yesterday patching up the AUR package for influxdb and noticed that it wasn't mentioned in the Downloads section. So I decided to add it.

![ss](https://cloud.githubusercontent.com/assets/4823640/2742282/f25e251e-c700-11e3-81a0-a5c61770a942.png "just in case you need convincing")


Thanks!