### PR TITLE
Note that automake needs to be installed on Debian-based distros.

### DIFF
--- a/source/docs/v0.7/contributing/building.md
+++ b/source/docs/v0.7/contributing/building.md
@@ -33,7 +33,7 @@ sudo yum install hg bzr protobuf-compiler flex bison valgrind g++ make autoconf 
 - If you're on a Debian-based distro:
 
 ``` bash
-sudo apt-get install mercurial bzr protobuf-compiler flex bison valgrind g++ make autoconf libtool libz-dev libbz2-dev
+sudo apt-get install mercurial bzr protobuf-compiler flex bison valgrind g++ make autoconf automake libtool libz-dev libbz2-dev
 ```
 
 Then run `./configure && make`. This will build the server and run the tests.


### PR DESCRIPTION
This package is necessary in order for the aclocal bin to be installed. aclocal is currently needed to build HyperLevelDB.