### PR TITLE
Add link to Heka HttpOutput module

### DIFF
--- a/source/layouts/docs.v0.8.index.html.slim
+++ b/source/layouts/docs.v0.8.index.html.slim
@@ -123,6 +123,7 @@ html
                 li= link_to "Chef Handler/Reporter", "https://github.com/SimpleFinance/chef-handler-influxdb"
                 li= link_to "Config Management via Boxen", "https://github.com/CargoSense/puppet-influxdb"
                 li= link_to "Shinken module", "https://github.com/savoirfairelinux/mod-influxdb"
+                li= link_to "Heka HttpOutput module", "http://hekad.readthedocs.org/en/latest/config/outputs/index.html#httpoutput"
 
                 = partial "/layouts/versions"
 


### PR DESCRIPTION
Mozilla Service's heka supports sending arbitrary messages (JSON formatted metrics, events) to InfluxDB via its generic HttpOutput.

Add a link to the latest version of the module documentation.