### PR TITLE
Links to some ruby gems

### DIFF
--- a/source/layouts/docs.v0.8.index.html.slim
+++ b/source/layouts/docs.v0.8.index.html.slim
@@ -117,6 +117,8 @@ html
                 li= link_to "CLI (Go)", "https://github.com/Dieterbe/influx-cli"
                 li= link_to "CLI (Node)", "https://github.com/FGRibreau/influxdb-cli"
                 li= link_to "CLI (Ruby)", "https://github.com/phstc/influxdb-cli"
+                li= link_to "Alternative ruby client (Ruby)", "https://github.com/undr/influxdb-api"
+                li= link_to "Query builder (Ruby)", "https://github.com/undr/influxdb-arel"
                 li= link_to "Grafana (dashboards)", "http://grafana.org/"
                 li= link_to "Graphite-Influxdb bridge", "https://github.com/vimeo/graphite-influxdb"
                 li= link_to "Tasseo (realtime dashboard)", "https://github.com/obfuscurity/tasseo"


### PR DESCRIPTION
Hi,
I've added some links to ruby gems which might be useful for the community. They are:

* **influxdb-api** (https://github.com/undr/influxdb-api) - alternative ruby client. It provides convenient access to almost all API endpoints (v0.8)

* **inffluxdb-arel** (https://github.com/undr/influxdb-arel) - query builder. It simplifies the generation of complex SQL queries for influxdb.

I'm going to keep improve them.  I wish to share them with community.