### PR TITLE
Fix link to Go client library

### DIFF
--- a/source/layouts/docs.v0.8.index.html.slim
+++ b/source/layouts/docs.v0.8.index.html.slim
@@ -93,7 +93,7 @@ html
                 li= link_to "Clojure", "https://github.com/olauzon/capacitor"
                 li= link_to "Common Lisp", "https://github.com/mmaul/cl-influxdb"
                 li= link_to "Java Metrics", "https://github.com/davidB/metrics-influxdb"
-                li= link_to "Go", "https://github.com/influxdb/influxdb-go"
+                li= link_to "Go", "https://github.com/influxdb/influxdb/tree/master/client"
                 li= link_to "Go Metrics", "https://github.com/rcrowley/go-metrics"
                 li= link_to "Scala", "https://github.com/influxdb/influxdb-scala"
                 li= link_to "R", "https://github.com/influxdb/influxdb-r"


### PR DESCRIPTION
The existing link was to a repo that forwarded to anther repo.