### PR TITLE
Fixup SSL options

### DIFF
--- a/source/docs/v0.6/advanced_topics/configuration_options.md
+++ b/source/docs/v0.6/advanced_topics/configuration_options.md
@@ -33,7 +33,7 @@ assets = "./admin"
 # Configure the http api
 [api]
 port     = 8086    # binding is disabled if the port isn't set
-# ssl-port = 8084    # Ssl support is enabled if you set a port and cert
+# ssl-port = 8084    # SSL support is enabled if you set a port and cert
 # ssl-cert = "/path/to/cert.pem"
 
 # connections will timeout after this amount of time. Ensures that clients that misbehave 

--- a/source/docs/v0.6/advanced_topics/configuration_options.md
+++ b/source/docs/v0.6/advanced_topics/configuration_options.md
@@ -34,7 +34,7 @@ assets = "./admin"
 [api]
 port     = 8086    # binding is disabled if the port isn't set
 # ssl-port = 8084    # Ssl support is enabled if you set a port and cert
-# ssl-cert = /path/to/cert.pem
+# ssl-cert = "/path/to/cert.pem"
 
 # connections will timeout after this amount of time. Ensures that clients that misbehave 
 # and keep alive connections they don't use won't end up connection a million times.

--- a/source/docs/v0.7/advanced_topics/configuration_options.md
+++ b/source/docs/v0.7/advanced_topics/configuration_options.md
@@ -26,7 +26,7 @@ assets = "./admin"
 [api]
 port     = 8086    # binding is disabled if the port isn't set
 # ssl-port = 8084    # Ssl support is enabled if you set a port and cert
-# ssl-cert = /path/to/cert.pem
+# ssl-cert = "/path/to/cert.pem"
 
 # connections will timeout after this amount of time. Ensures that clients that misbehave 
 # and keep alive connections they don't use won't end up connection a million times.

--- a/source/docs/v0.7/advanced_topics/configuration_options.md
+++ b/source/docs/v0.7/advanced_topics/configuration_options.md
@@ -25,7 +25,7 @@ assets = "./admin"
 # Configure the http api
 [api]
 port     = 8086    # binding is disabled if the port isn't set
-# ssl-port = 8084    # Ssl support is enabled if you set a port and cert
+# ssl-port = 8084    # SSL support is enabled if you set a port and cert
 # ssl-cert = "/path/to/cert.pem"
 
 # connections will timeout after this amount of time. Ensures that clients that misbehave 

--- a/source/docs/v0.8/advanced_topics/configuration_options.md
+++ b/source/docs/v0.8/advanced_topics/configuration_options.md
@@ -26,7 +26,7 @@ assets = "./admin"
 [api]
 port     = 8086    # binding is disabled if the port isn't set
 # ssl-port = 8084    # Ssl support is enabled if you set a port and cert
-# ssl-cert = /path/to/cert.pem
+# ssl-cert = "/path/to/cert.pem"
 
 # connections will timeout after this amount of time. Ensures that clients that misbehave 
 # and keep alive connections they don't use won't end up connection a million times.

--- a/source/docs/v0.8/advanced_topics/configuration_options.md
+++ b/source/docs/v0.8/advanced_topics/configuration_options.md
@@ -25,7 +25,7 @@ assets = "./admin"
 # Configure the http api
 [api]
 port     = 8086    # binding is disabled if the port isn't set
-# ssl-port = 8084    # Ssl support is enabled if you set a port and cert
+# ssl-port = 8084    # SSL support is enabled if you set a port and cert
 # ssl-cert = "/path/to/cert.pem"
 
 # connections will timeout after this amount of time. Ensures that clients that misbehave 


### PR DESCRIPTION
- Properly quote the path to `ssl-cert`
- Upcase SSL abbreviation 