### PR TITLE
Fix typo in Querying Data example

### DIFF
--- a/source/docs/v0.9/query_language/querying_data.md
+++ b/source/docs/v0.9/query_language/querying_data.md
@@ -4,7 +4,7 @@ InfluxDB features an SQL-like query language for querying data and performing ag
 The primary mechanism for issuing any of the queries listed below is through the HTTP API. For example, the command `SELECT * FROM cpu` can be executed using `curl` as follows:
 
 ```
-curl -G 'http://localhost:8086/query' --data-urlencode "q=SELECT * FROM foo"
+curl -G 'http://localhost:8086/query' --data-urlencode "q=SELECT * FROM cpu"
 ```
 ## Quote Usage
 *Identifiers* are either unquoted or double quoted. Identifiers are database names, retention policies, measurements, or tag keys. String literals are always single quoted however.


### PR DESCRIPTION
The curl example had "select * from foo", but the paragraph above refers to querying the "cpu" series.